### PR TITLE
typo fix in MetadataDetectorForm zoom property

### DIFF
--- a/omeroweb/webclient/forms.py
+++ b/omeroweb/webclient/forms.py
@@ -2652,7 +2652,7 @@ class MetadataDetectorForm(forms.Form):
                     widget=forms.TextInput(
                         attrs={
                             "size": 25,
-                            "onchange": save_metadata(detector.id, "voltage"),
+                            "onchange": save_metadata(detector.id, "zoom"),
                         }
                     ),
                     initial=detector.zoom,
@@ -2664,7 +2664,7 @@ class MetadataDetectorForm(forms.Form):
                     widget=forms.TextInput(
                         attrs={
                             "size": 25,
-                            "onchange": save_metadata(detector.id, "voltage"),
+                            "onchange": save_metadata(detector.id, "zoom"),
                         }
                     ),
                     required=False,


### PR DESCRIPTION
For the zoom property of the MetadataDetectorForm, the onchange event uses the wrong key `voltage` which is certainly a typo.

